### PR TITLE
Specify Fatiando 0.5 from conda-forge in environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,9 @@
 # Activate the environmet to run the code using "source activate ellipsoids"
 # or "activate ellipsoids" on Windows.
 name: ellipsoids
+channels:
+    - defaults
+    - conda-forge
 dependencies:
     - python=2.7
     - pip
@@ -12,5 +15,4 @@ dependencies:
     - pytest
     - pytest-cov
     - flake8
-    - pip:
-        - fatiando
+    - fatiando=0.5


### PR DESCRIPTION
This makes it clear which version of Fatiando is being used and
downloads the pre-compiled binaries from conda-forge. Makes it a lot
easier for users on Windows to create the environment.